### PR TITLE
Fixes trigger of playerRegistered twice

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -13,8 +13,6 @@ AddEventHandler('esx_identity:alreadyRegistered', function()
 	while not loadingScreenFinished do
 		Citizen.Wait(100)
 	end
-
-	TriggerEvent('esx_skin:playerRegistered')
 end)
 
 AddEventHandler('esx:loadingScreenOff', function()


### PR DESCRIPTION
Well, we don't want to trigger esx_skin twice (first when loading screen is off, second is when registered)